### PR TITLE
The admin panel is not a global hook anymore

### DIFF
--- a/bin/extensio-lift.js
+++ b/bin/extensio-lift.js
@@ -31,8 +31,7 @@ module.exports = function () {
 
   log.info('Starting the application...');
 
-  // Build initial scope, mixing-in `rc` config and
-  // load the admin "hook".
+  // Build initial scope, mixing-in `rc` config.
   var scope = _.merge({
     rootPath: process.cwd(),
     sailsPackageJSON: package

--- a/bin/extensio-new.js
+++ b/bin/extensio-new.js
@@ -33,7 +33,7 @@ module.exports = function () {
   // Pass the original CLI arguments down to the generator.
   var cliArguments = Array.prototype.slice.call(arguments);
 
-  // Build initial scope and load the admin "hook".
+  // Build initial scope.
   scope = {
     rootPath: process.cwd(),
     sailsRoot: path.resolve(__dirname, '..'),


### PR DESCRIPTION
When we started to develop extens.io, the admin dashboard was a global hook. It's now a module because hooks are reserved for the framework and modules for the application features.