### PR TITLE
Better open governance guide lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## v0.11.1
+*Only notable changes are written.*
 
-- Add `extensio` command-line for Windows.
-- Delete duplicate Sails dependencies.
-- Delete `grunt-browser-sync` dependency.
+
+## v0.11.1
+### 2015-01-21
+
+- **[FIX]** Add `extensio` as a valid command to avoid conflicts on Windows. In fact, Windows thinks `extens.io` is a file since there is a dot. By [@loicsaintroch](https://github.com/loicsaintroch).
+- **[ENHANCEMENT]** Delete duplicated Sails dependencies. Remove the Sails dependencies and use relative paths to the node modules avoid useless deep dependencies and duplicated node modules. By [@loicsaintroch](https://github.com/loicsaintroch).
+- **[FIX]** Delete `grunt-browser-sync` dependency to avoid conflicts with Socket.IO and require useless deep dependencies. By [@loicsaintroch](https://github.com/loicsaintroch).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,19 @@
 # Contributing
 
-## Pull requests
+## Issues and pull requests
 
-### Introducing pull requests
+When opening new issues or commenting on existing issues on this repository please make sure discussions are related to concrete technical issues with the extens.io ecosystem.
 
-Pull requests are always welcome, but note that all pull requests must be sent to the `development` branch.
+Courtesy should always be shown to individuals submitting issues and pull requests to the extens.io project.
 
-We are always thrilled to receive pull requests, and do our best to process them as fast as possible. Not sure if that typo is worth a pull request? Do it! We will appreciate it.
+Collaborators should feel free to take full responsibility for managing issues and pull requests they feel qualified to handle, as long as this is done while being mindful of these guidelines, the opinions of other Collaborators and guidance of the TC.
 
-If your pull request is not accepted on the first try, don't be discouraged! If there's a problem with the implementation, hopefully you received feedback on what to improve.
+Collaborators may close any issue or pull request they believe is not relevant for the future of the extens.io project. Where this is unclear, the issue should be left open for several days to allow for additional discussion. Where this does not yield input from extens.io Collaborators or additional evidence that the issue has relevance, the issue may be closed. Remember that issues can always be re-opened if necessary.
 
 We're trying very hard to keep our ecosystem lean and focused. We don't want it to do everything for everybody. This means that we might decide against incorporating a new feature.
 
 A great pull request contains:
+
 - Minimal changes. Only submit code relevant to the current issue. Other changes should go in new pull requests.
 - Minimal commits. Please squash to a single commit before sending your pull request.
 - No conflicts. Please rebase off the latest `development` branch before submitting.
@@ -21,7 +22,22 @@ A great pull request contains:
 - Relevant comments and documentation.
 
 
-### Workflow
+## Accepting modifications
+
+All modifications to the the extens.io code should be performed via GitHub pull requests, including modifications by Collaborators and TC members.
+
+All pull requests must be reviewed and accepted by a Collaborator with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing Collaborator, an additional Collaborator is required for sign-off.
+
+In some cases, it may be necessary to summon a qualified Collaborator to a pull request for review by @-mention.
+
+If you are unsure about the modification and are not prepared to take full responsibility for the change, defer to another Collaborator.
+
+Where there is no disagreement amongst Collaborators, a pull request may be landed given appropriate review. Where there is discussion amongst Collaborators, consensus should be sought if possible. The lack of consensus may indicate the need to elevate discussion to the TC for resolution (see below).
+
+
+## Workflow
+
+The extens.io project has an open governance model and welcomes new contributors. Individuals making significant and valuable contributions are made Collaborators and given commit-access to the project.
 
 Adhering to the following process is the best way to get your work included in the project:
 
@@ -58,17 +74,23 @@ Adhering to the following process is the best way to get your work included in t
 
 ## License
 
-By contributing your code to this repository, you agree to license your contribution under the MIT license.
+By making a contribution to this project, I certify that:
+
+- (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+- (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+- (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+
+By contributing your code to the [@extensdotio](https://github.com/extensdotio) repositories, you agree to license your contribution under the MIT license.
 
 See [MIT License](LICENSE.md) for more information.
 
 
 ## Code of conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+As Contributors of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
 We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, age, or religion.
 
 Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+The TC have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the TC.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,49 @@
+# Open-source governance
+
+## Technical Committee
+
+The extens.io project is jointly governed by a Technical Committee (TC) which is responsible for high-level guidance of the project.
+
+The TC has final authority over this project including:
+
+* Technical direction
+* Project governance and process (including this policy)
+* Contribution policy
+* GitHub repository hosting
+* Conduct guidelines
+* Maintaining the list of additional Collaborators
+
+Initial membership invitations to the TC were given to individuals who had been active contributors to extens.io, and who have significant experience with the management of the extens.io project. Membership is expected to evolve over time according to the needs of the project.
+
+
+## Collaborators
+
+The [@extensdotio](https://github.com/extensdotio) GitHub repositories are maintained by the TC and additional Collaborators who are added by the TC on an ongoing basis.
+
+Individuals making significant and valuable contributions are made Collaborators and given commit-access to the project. These individuals are identified by the TC and their addition as Collaborators is discussed during the weekly TC meeting.
+
+Modifications of the contents of the [@extensdotio](https://github.com/extensdotio) repositories are made on a collaborative basis. Anybody with a GitHub account may propose a modification via pull request and it will be considered by the project Collaborators. All pull requests must be reviewed and accepted by a Collaborator with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing Collaborator, an additional Collaborator is required for sign-off. Consensus should be sought if additional Collaborators participate and there is disagreement around a particular modification. See _Consensus Seeking Process_ below for further detail on the consensus model used for governance.
+
+
+## TC Membership
+
+TC seats are not time-limited. There is no fixed size of the TC. However, the expected target is between 4 and 8, to ensure adequate coverage of important areas of expertise, balanced with the ability to make decisions efficiently.
+
+There is no specific set of requirements or qualifications for TC membership beyond these rules.
+
+The TC may add additional members to the TC by unanimous consensus.
+
+A TC member may be removed from the TC by voluntary resignation, or by unanimous consensus of all other TC members.
+
+If an addition or removal is proposed during a meeting, and the full TC is not in attendance to participate, then the addition or removal is added to the agenda for the subsequent meeting. This is to ensure that all members are given the opportunity to participate in all membership decisions. If a TC member is unable to attend a meeting where a planned membership decision is being made, then their consent is assumed.
+
+
+## Consensus Seeking Process
+
+The TC follows a [Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making) decision making model.
+
+When an agenda item has appeared to reach a consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
+
+If an agenda item cannot reach a consensus a TC member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be seconded by a majority of the TC or else the discussion will continue. Simple majority wins.
+
+Note that changes to TC membership require unanimous consensus. See "TC Membership" above.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 extens.io is an open-source governance Node.js ecosystem to make a new kind of realtime web applications build on top of the Sails framework.
 
-Sails is the framework. Build on top of the Sails framework using the extens.io ecosystem means your application requires Sails and you trust extens.io to give you more features, hooks, updates, etc.
+Build on top of the Sails framework using the extens.io ecosystem means your application requires Sails and you trust extens.io to give you more features, hooks, updates, etc.
+
+extens.io contributions, releases, and contributorship are under an open governance model. We intend to land, with increasing regularity, releases which are compatible with Sails and Waterline.
 
 
 ## Notes
 
 This is a developer preview and not ready for production yet. A lot of work still need to be done. Please see our [roadmap](ROADMAP.md) to have more information about our plans.
 
-We currently require our ecosystem dependencies from GitHub but we'll create a npm registry for the alpha version.
+We currently require our ecosystem dependencies from GitHub but we'll create a npm registry for the beta version.
 
 Documentation will come soon. In the meantime, you can access the official Sails documentation here: [http://sailsjs.org/#/documentation](http://sailsjs.org/#/documentation).
 
@@ -22,16 +24,6 @@ Documentation will come soon. In the meantime, you can access the official Sails
 
 
 ## Getting started
-
-### npm cache
-
-If you already installed a previous version of extens.io, please do:
-
-```bash
-$ [sudo] npm uninstall extens.io -g
-$ [sudo] npm cache clear
-```
-
 
 ### Basics
 
@@ -47,7 +39,6 @@ Before doing anything else, please make sure you have a MongoDB process running:
 $ mongod
 ```
 
-
 Create and lift your first application with:
 
 ```bash
@@ -55,6 +46,8 @@ $ extens.io new myApp [--no-frontend]
 $ cd myApp
 $ extens.io lift
 ```
+
+Note: On Windows, you will probably need to run `$ extensio` instead of `$ extens.io`.
 
 You can access your admin dashboard at [http://localhost:1337/sails-admin/](http://localhost:1337/sails-admin/).
 
@@ -71,15 +64,15 @@ $ extens.io console
 
 ## About us
 
-We are a bunch of students from Paris, France. We often have some tests, school and freelance projects. extens.io is a side-project for us (for now), but it is made with trust, love and passion. We welcome every feedback and request.
+The extens.io project team comprises a group of core collaborators and a sub-group that forms the Technical Committee (TC) which governs the project.
 
-The team:
+- Loïc Saint-Roch ([@loicsaintroch](https://github.com/loicsaintroch))
+- Aurélien Georget ([@aurelsicoko](https://github.com/aurelsicoko))
+- Jim Laurie ([@hack1337](https://github.com/hack1337))
+- Pierre Burgy ([@pierreburgy](https://github.com/pierreburgy))
+- Hugo Caillard ([@hugocaillard](https://github.com/hugocaillard))
 
-- [Loïc Saint-Roch](https://github.com/loicsaintroch)
-- [Aurélien Georget](https://github.com/aurelsicoko)
-- [Jim Laurie](https://github.com/hack1337)
-- [Pierre Burgy](https://github.com/pierreburgy)
-- [Hugo Caillard](https://github.com/hugocaillard)
+Collaborators should be familiar with the [guidelines](CONTRIBUTING.md) and also understand the project governance model as outlined in [the open governance document](GOVERNANCE.md).
 
 We owe huge gratitude and props to the authors of all the open-source projects we use. We want to thank every contributors who helped us make this project better every day. extens.io could never have been developed without your tremendous contributions.
 
@@ -90,6 +83,7 @@ We owe huge gratitude and props to the authors of all the open-source projects w
 - [Changelog](CHANGELOG.md)
 - [Roadmap](ROADMAP.md)
 - [Contributing guide](CONTRIBUTING.md)
+- [Open governance](GOVERNANCE.md)
 - [MIT License](LICENSE.md)
 
 
@@ -98,3 +92,4 @@ We owe huge gratitude and props to the authors of all the open-source projects w
 - [Website](http://extens.io/)
 - [Ecosystem](https://github.com/extensdotio)
 - [Twitter](https://twitter.com/extensdotio)
+- [Gitter](https://gitter.im/extensdotio/extens.io)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,17 +2,6 @@
 
 List of new features we'll be working on soon:
 
-* **v0.11.0** (developer preview, current version)
-  * Own fork of Sails
-  * Front-end workflow with Grunt and Bower
-  * Global admin module
-  * Command-Line Interface
-  * Custom generators
-  * Create basic APIs from the UI
-  * Settings and models in JSON
-  * Custom font icons (the Witicons)
-
-
 * **v0.12.0**
   * i18n
     * for the global admin module
@@ -68,7 +57,7 @@ List of new features we'll be working on soon:
     * List every models
     * Display data from a specific model
     * Add, edit and remove data
-    * Cross data between differents models
+    * Cross data between different models
 
 
 * **v0.19.0** (alpha version)
@@ -89,29 +78,26 @@ List of new features we'll be working on soon:
 
 # Wishlist
 
-List of really good things we probably won't do:
-
-  * ArangoDB adapter (we are in love, we really need this stuff)
-  * Monitoring dashboard with pm2
-  * Ionic generator
+* ArangoDB adapter (we are in love, we really need this stuff)
+* Monitoring dashboard with pm2
+* Ionic generator
 
 [Feel free to help us on making the ecosystem better everyday.](CONTRIBUTING.md)
 
 
 # Todo
 
-List of improvements we can make on the ecosystem:
+List of technical improvements we can make on the ecosystem:
 
 * Better connections management between the application and the modules (`sails-hook-userfeatures`).
-* Update tests to make them work (`sails`, `sails-generate`, `sails-hook-cors`, `sails-hook-csrf`, `sails-hook-i18n`, `sails-hook-policies`, `sails-hook-pubsub`, `sails-hook-request`, `sails-hook-sockets`, `sails-hook-userconfig` and `sails-hook-views`). **Owner**: @loicsaintroch
+* Update tests to make them work (`sails`, `sails-generate`, `sails-hook-cors`, `sails-hook-csrf`, `sails-hook-i18n`, `sails-hook-policies`, `sails-hook-pubsub`, `sails-hook-request`, `sails-hook-sockets`, `sails-hook-userconfig` and `sails-hook-views`). **Owner**: [@loicsaintroch](https://github.com/loicsaintroch)
 * Write tests for every hooks without tests.
 * Continuous Integration with Travis.
 * Get rid of `sails-util`.
-* Merge `sails-generate-controller`, `sails-generate-controller-module` and `sails-generate-controller-template` into one generator (`sails-generate-controller`). **Owner**: @loicsaintroch
-* Merge `sails-generate-model`, `sails-generate-model-module` and `sails-generate-model-template` into one generator (`sails-generate-model`). **Owner**: @loicsaintroch
+* Merge `sails-generate-controller`, `sails-generate-controller-module` and `sails-generate-controller-template` into one generator (`sails-generate-controller`). **Owner**: [@loicsaintroch](https://github.com/loicsaintroch)
+* Merge `sails-generate-model`, `sails-generate-model-module` and `sails-generate-model-template` into one generator (`sails-generate-model`). **Owner**: [@loicsaintroch](https://github.com/loicsaintroch)
 * Improve `sails-hook-views` for layouts support. We also can simplify the hook.
-* `sails-hook-machines` should work even if there is `./api/machines` directory. **Owner**: @loicsaintroch
-* The default views inside `sails-generate-views-ejs` should use Foundation assets. **Owner**: @loicsaintroch
+* `sails-hook-machines` should work even if there is no `./api/machines` directory. **Owner**: [@loicsaintroch](https://github.com/loicsaintroch)
 
 If you are feeling pretty confident helping us, please make a pull request and add you as `owner` of the improvement or create a new one. We'll discuss on the subject and if the community agrees we'll merge your proposal and let you write your pull request on the desired repositories.
 


### PR DESCRIPTION
Updated open governance guide lines with a lot of details. Most of the guide lines come from [https://github.com/iojs/io.js](io.js). Also added a link to Gitter.